### PR TITLE
use -fPIC, so lua is suitable for inclusion in a library.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,8 @@
 if [ `uname` == Darwin ]; then
-	make macosx INSTALL_TOP=$PREFIX MYCFLAGS="-I$PREFIX/include -L$PREFIX/lib -DLUA_USER_DEFAULT_PATH='\"$PREFIX/\"'" MYLDFLAGS="-L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
+	make macosx INSTALL_TOP=$PREFIX MYCFLAGS="-fPIC -I$PREFIX/include -L$PREFIX/lib -DLUA_USER_DEFAULT_PATH='\"$PREFIX/\"'" MYLDFLAGS="-L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
 	make macosx test
 elif [ `uname` == Linux ]; then
-	make linux INSTALL_TOP=$PREFIX MYCFLAGS="-I$PREFIX/include -L$PREFIX/lib -DLUA_USE_LINUX -DLUA_USER_DEFAULT_PATH='\"$PREFIX/\"'" MYLDFLAGS="-L$PREFIX/lib -Wl,-rpath=$PREFIX/lib"
+	make linux INSTALL_TOP=$PREFIX MYCFLAGS="-fPIC -I$PREFIX/include -L$PREFIX/lib -DLUA_USE_LINUX -DLUA_USER_DEFAULT_PATH='\"$PREFIX/\"'" MYLDFLAGS="-L$PREFIX/lib -Wl,-rpath=$PREFIX/lib"
 	make linux test
 fi
 make install INSTALL_TOP=$PREFIX

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - Makefile.patch
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   skip: True  # [win]
 


### PR DESCRIPTION
 Otherwise the following error is found: 

    /usr/bin/ld: myLib.o: relocation R_X86_64_32 against a local symbol can not be used when making a shared object; recompile with -fPIC